### PR TITLE
Follow ASDF3 guideline of a single primary system per .asd file

### DIFF
--- a/a-cl-logger-logstash.asd
+++ b/a-cl-logger-logstash.asd
@@ -1,9 +1,3 @@
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (unless (find-package :a-cl-logger.system)
-    (defpackage :a-cl-logger.system
-      (:use :common-lisp :asdf))))
-
-(in-package :a-cl-logger.system)
  
 (defsystem :a-cl-logger-logstash
   :description "Load the logstash appender for a-cl-logger"

--- a/a-cl-logger.asd
+++ b/a-cl-logger.asd
@@ -1,9 +1,3 @@
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (unless (find-package :a-cl-logger.system)
-    (defpackage :a-cl-logger.system
-      (:use :common-lisp :asdf))))
-
-(in-package :a-cl-logger.system)
  
 (defsystem :a-cl-logger
   :description "A logger that sends to multiple destinations in multiple formats. Based on arnesi logger"
@@ -18,18 +12,16 @@
    (:file "appenders")
    (:file "helpers"))
   :depends-on (:iterate :symbol-munger :alexandria :cl-interpol :cl-json :local-time
-                :cl-json :closer-mop :osicat :exit-hooks))
+                :cl-json :closer-mop :osicat :exit-hooks)
+  :in-order-to ((test-op (test-op :a-cl-logger/tests))))
 
-(defsystem :a-cl-logger-tests
+(defsystem :a-cl-logger/tests
   :description "Tests for: a-cl-logger"
   :author "Russ Tyndall <russ@acceleration.net>, Nathan Bird <nathan@acceleration.net>, Ryan Davis <ryan@acceleration.net>"
   :licence "BSD"
   :serial t
   :components
   ((:file "tests"))
-  :depends-on (:lisp-unit2 :a-cl-logger))
-
-(defmethod asdf:perform ((o asdf:test-op) (c (eql (asdf:find-system :a-cl-logger))))
-  (asdf:load-system :a-cl-logger-tests)
-  (let ((*package* (find-package :a-cl-logger)))
-    (eval (read-from-string "(run-tests)"))))
+  :depends-on (:lisp-unit2 :a-cl-logger)
+  :perform (test-op (op system)
+             (uiop:symbol-call :a-cl-logger 'run-tests)))


### PR DESCRIPTION
ASDF3 recommends a single primary system per `.asd` file (e.g., `FOO`), with other, optional subsystems being named with a slash (e.g., `FOO/BAR`). This ensures that `FOO/BAR` can be loaded without first having to manually load `FOO`, as would be the case with e.g. `FOO-BAR` (ASDF would look for it in a non-existent `foo-bar.asd`).

See: [info asdf find-system](https://asdf.common-lisp.dev/asdf.html#Components-1)


Additionally:

Why was the `(in-package :a-cl-logger.system)` necessary?